### PR TITLE
add env vars to override git urls for auth

### DIFF
--- a/src/main/java/com/epam/reportportal/auth/integration/github/GitHubClient.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GitHubClient.java
@@ -35,23 +35,22 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 import java.util.List;
 
-import static java.util.Optional.ofNullable;
-
 /**
  * Simple GitHub client
  *
  * @author <a href="mailto:andrei_varabyeu@epam.com">Andrei Varabyeu</a>
  */
+
 public class GitHubClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHubClient.class);
 
-    private static final String GITHUB_BASE_URL = ofNullable(System.getenv("GITHUB_API_URL")).orElse("https://api.github.com");
+    private final String githubBaseUrl;
 
     private final RestTemplate restTemplate;
 
 
-    private GitHubClient(String accessToken) {
+    private GitHubClient(String accessToken, String githubBaseUrl) {
         this.restTemplate = new RestTemplate();
         this.restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
             @Override
@@ -65,23 +64,24 @@ public class GitHubClient {
             request.getHeaders().add("Authorization", "bearer " + accessToken);
             return execution.execute(request, body);
         });
+        this.githubBaseUrl=githubBaseUrl;
     }
 
-    public static GitHubClient withAccessToken(String accessToken) {
-        return new GitHubClient(accessToken);
+    public static GitHubClient withAccessToken(String accessToken, String githubBaseUrl) {
+        return new GitHubClient(accessToken, githubBaseUrl);
     }
 
     public UserResource getUser() {
-        return this.restTemplate.getForObject(GITHUB_BASE_URL + "/user", UserResource.class);
+        return this.restTemplate.getForObject(this.githubBaseUrl + "/user", UserResource.class);
     }
 
     public List<EmailResource> getUserEmails() {
-        return getForObject(GITHUB_BASE_URL + "/user/emails", new ParameterizedTypeReference<List<EmailResource>>() {
+        return getForObject(this.githubBaseUrl + "/user/emails", new ParameterizedTypeReference<List<EmailResource>>() {
         });
     }
 
     public List<OrganizationResource> getUserOrganizations(String user) {
-        return getForObject(GITHUB_BASE_URL + "/users/{}/orgs", new ParameterizedTypeReference<List<OrganizationResource>>() {
+        return getForObject(this.githubBaseUrl + "/users/{}/orgs", new ParameterizedTypeReference<List<OrganizationResource>>() {
         }, user);
     }
 

--- a/src/main/java/com/epam/reportportal/auth/integration/github/GitHubClient.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GitHubClient.java
@@ -35,6 +35,8 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 import java.util.List;
 
+import static java.util.Optional.ofNullable;
+
 /**
  * Simple GitHub client
  *
@@ -44,7 +46,7 @@ public class GitHubClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHubClient.class);
 
-    private static final String GITHUB_BASE_URL = "https://api.github.com";
+    private static final String GITHUB_BASE_URL = ofNullable(System.getenv("GITHUB_API_URL")).orElse("https://api.github.com");
 
     private final RestTemplate restTemplate;
 

--- a/src/main/java/com/epam/reportportal/auth/integration/github/GitHubTokenServices.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GitHubTokenServices.java
@@ -50,15 +50,17 @@ public class GitHubTokenServices implements ResourceServerTokenServices {
 
     private final GitHubUserReplicator replicator;
     private final Supplier<OAuth2LoginDetails> loginDetails;
+    private final String githubBaseUrl;
 
-    public GitHubTokenServices(GitHubUserReplicator replicatingPrincipalExtractor, Supplier<OAuth2LoginDetails> loginDetails) {
+    public GitHubTokenServices(GitHubUserReplicator replicatingPrincipalExtractor, Supplier<OAuth2LoginDetails> loginDetails, String githubBaseUrl) {
         this.replicator = replicatingPrincipalExtractor;
         this.loginDetails = loginDetails;
+        this.githubBaseUrl = githubBaseUrl;
     }
 
     @Override
     public OAuth2Authentication loadAuthentication(String accessToken) throws AuthenticationException, InvalidTokenException {
-        GitHubClient gitHubClient = GitHubClient.withAccessToken(accessToken);
+        GitHubClient gitHubClient = GitHubClient.withAccessToken(accessToken, this.githubBaseUrl);
         UserResource gitHubUser = gitHubClient.getUser();
 
         List<String> allowedOrganizations = ofNullable(loginDetails.get().getRestrictions())

--- a/src/main/java/com/epam/reportportal/auth/integration/github/GithubOAuthProvider.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GithubOAuthProvider.java
@@ -56,10 +56,12 @@ public class GithubOAuthProvider extends com.epam.reportportal.auth.oauth.OAuthP
     public void applyDefaults(OAuth2LoginDetails details) {
         details.setScope(ofNullable(details.getScope()).orElse(Arrays.asList("read:user", "user:email")));
         details.setGrantType(ofNullable(details.getGrantType()).orElse("authorization_code"));
+        final String tokeUrl = ofNullable(System.getenv("GITHUB_ACCESS_TOKEN_URL")).orElse(details.getAccessTokenUri());
+        final String oauthUrl = ofNullable(System.getenv("GITHUB_OAUTH_URL")).orElse(details.getUserAuthorizationUri());
         details.setAccessTokenUri(
-                ofNullable(details.getAccessTokenUri()).orElse("https://github.com/login/oauth/access_token"));
+                ofNullable(tokeUrl).orElse("https://github.com/login/oauth/access_token"));
         details.setUserAuthorizationUri(
-                ofNullable(details.getUserAuthorizationUri()).orElse("https://github.com/login/oauth/authorize"));
+                ofNullable(oauthUrl).orElse("https://github.com/login/oauth/authorize"));
         details.setClientAuthenticationScheme(ofNullable(details.getClientAuthenticationScheme()).orElse("form"));
     }
 

--- a/src/main/java/com/epam/reportportal/auth/integration/github/GithubOAuthProvider.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GithubOAuthProvider.java
@@ -22,6 +22,7 @@ package com.epam.reportportal.auth.integration.github;
 
 import com.epam.reportportal.auth.AuthConfigService;
 import com.epam.ta.reportportal.database.entity.settings.OAuth2LoginDetails;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.OAuth2ClientContext;
 import org.springframework.security.oauth2.client.OAuth2RestOperations;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
@@ -44,30 +45,38 @@ public class GithubOAuthProvider extends com.epam.reportportal.auth.oauth.OAuthP
 
     private final GitHubUserReplicator githubReplicator;
     private final AuthConfigService authConfigService;
+    private final String tokenUrl;
+    private final String authUrl;
+    private final String githubBaseUrl;
 
     public GithubOAuthProvider(GitHubUserReplicator githubReplicator,
-                               AuthConfigService authConfigService) {
+                               AuthConfigService authConfigService,
+                               @Value("${rp.auth.github.tokenUrl:https://github.com/login/oauth/access_token}") String tokenUrl,
+                               @Value("${rp.auth.github.authUrl:https://github.com/login/oauth/authorize}") String authUrl,
+                               @Value("${rp.auth.github.apiUrl:https://api.github.com}") String githubBaseUrl) {
         super("github", BUTTON, true);
         this.githubReplicator = githubReplicator;
         this.authConfigService = authConfigService;
+        this.tokenUrl = tokenUrl;
+        this.authUrl = authUrl;
+        this.githubBaseUrl = githubBaseUrl;
     }
 
     @Override
     public void applyDefaults(OAuth2LoginDetails details) {
         details.setScope(ofNullable(details.getScope()).orElse(Arrays.asList("read:user", "user:email")));
         details.setGrantType(ofNullable(details.getGrantType()).orElse("authorization_code"));
-        final String tokeUrl = ofNullable(System.getenv("GITHUB_ACCESS_TOKEN_URL")).orElse(details.getAccessTokenUri());
-        final String oauthUrl = ofNullable(System.getenv("GITHUB_OAUTH_URL")).orElse(details.getUserAuthorizationUri());
+
         details.setAccessTokenUri(
-                ofNullable(tokeUrl).orElse("https://github.com/login/oauth/access_token"));
+                ofNullable(details.getAccessTokenUri()).orElse(this.tokenUrl));
         details.setUserAuthorizationUri(
-                ofNullable(oauthUrl).orElse("https://github.com/login/oauth/authorize"));
+                ofNullable(details.getUserAuthorizationUri()).orElse(this.authUrl));
         details.setClientAuthenticationScheme(ofNullable(details.getClientAuthenticationScheme()).orElse("form"));
     }
 
     @Override
     public ResourceServerTokenServices getTokenServices() {
-        return new GitHubTokenServices(githubReplicator, authConfigService.getLoginDetailsSupplier(getName()));
+        return new GitHubTokenServices(githubReplicator, authConfigService.getLoginDetailsSupplier(getName()), this.githubBaseUrl);
     }
 
     @Override


### PR DESCRIPTION
Trying to make it easy to use github enterprise by adding env variables.  The default behavior stays the same.
Example
environment:
      - RP_AUTH_GITHUB_APIURL=https://{{host}}/api/v3
      - RP_AUTH_GITHUB_TOKENURL=https://{{host}}/login/oauth/access_token
      - RP_AUTH_GITHUB_AUTHURL=https://{{host}}/login/oauth/authorize

issue #48