### PR TITLE
Adding settings for github urls to allow enterprise github

### DIFF
--- a/src/main/java/com/epam/reportportal/auth/integration/github/GitHubClient.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GitHubClient.java
@@ -44,12 +44,12 @@ public class GitHubClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHubClient.class);
 
-    private static final String GITHUB_BASE_URL = "https://api.github.com";
+    private final String githubBaseUrl;
 
     private final RestTemplate restTemplate;
 
 
-    private GitHubClient(String accessToken) {
+    private GitHubClient(String accessToken, String githubBaseUrl) {
         this.restTemplate = new RestTemplate();
         this.restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
             @Override
@@ -63,23 +63,24 @@ public class GitHubClient {
             request.getHeaders().add("Authorization", "bearer " + accessToken);
             return execution.execute(request, body);
         });
+        this.githubBaseUrl=githubBaseUrl;
     }
 
-    public static GitHubClient withAccessToken(String accessToken) {
-        return new GitHubClient(accessToken);
+    public static GitHubClient withAccessToken(String accessToken, String githubBaseUrl) {
+        return new GitHubClient(accessToken, githubBaseUrl);
     }
 
     public UserResource getUser() {
-        return this.restTemplate.getForObject(GITHUB_BASE_URL + "/user", UserResource.class);
+        return this.restTemplate.getForObject(this.githubBaseUrl + "/user", UserResource.class);
     }
 
     public List<EmailResource> getUserEmails() {
-        return getForObject(GITHUB_BASE_URL + "/user/emails", new ParameterizedTypeReference<List<EmailResource>>() {
+        return getForObject(this.githubBaseUrl + "/user/emails", new ParameterizedTypeReference<List<EmailResource>>() {
         });
     }
 
     public List<OrganizationResource> getUserOrganizations(String user) {
-        return getForObject(GITHUB_BASE_URL + "/users/{}/orgs", new ParameterizedTypeReference<List<OrganizationResource>>() {
+        return getForObject(this.githubBaseUrl + "/users/{}/orgs", new ParameterizedTypeReference<List<OrganizationResource>>() {
         }, user);
     }
 

--- a/src/main/java/com/epam/reportportal/auth/integration/github/GitHubTokenServices.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GitHubTokenServices.java
@@ -50,15 +50,17 @@ public class GitHubTokenServices implements ResourceServerTokenServices {
 
     private final GitHubUserReplicator replicator;
     private final Supplier<OAuth2LoginDetails> loginDetails;
+    private final String githubBaseUrl;
 
-    public GitHubTokenServices(GitHubUserReplicator replicatingPrincipalExtractor, Supplier<OAuth2LoginDetails> loginDetails) {
+    public GitHubTokenServices(GitHubUserReplicator replicatingPrincipalExtractor, Supplier<OAuth2LoginDetails> loginDetails, String githubBaseUrl) {
         this.replicator = replicatingPrincipalExtractor;
         this.loginDetails = loginDetails;
+        this.githubBaseUrl = githubBaseUrl;
     }
 
     @Override
     public OAuth2Authentication loadAuthentication(String accessToken) throws AuthenticationException, InvalidTokenException {
-        GitHubClient gitHubClient = GitHubClient.withAccessToken(accessToken);
+        GitHubClient gitHubClient = GitHubClient.withAccessToken(accessToken, this.githubBaseUrl);
         UserResource gitHubUser = gitHubClient.getUser();
 
         List<String> allowedOrganizations = ofNullable(loginDetails.get().getRestrictions())

--- a/src/main/java/com/epam/reportportal/auth/integration/github/GitHubUserReplicator.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GitHubUserReplicator.java
@@ -60,7 +60,7 @@ public class GitHubUserReplicator extends AbstractUserReplicator {
     @Autowired
     public GitHubUserReplicator(UserRepository userRepository, ProjectRepository projectRepository, DataStorage dataStorage,
                                 PersonalProjectService personalProjectService,
-                                @Value("${rp.auth.github.apiUrl:https://api.github.com}") String githubBaseUrl) {
+                                @Value("${rp.auth.github.apiUrl}") String githubBaseUrl) {
         super(userRepository, projectRepository, personalProjectService, dataStorage);
         this.githubBaseUrl=githubBaseUrl;
     }

--- a/src/main/java/com/epam/reportportal/auth/integration/github/GithubOAuthProvider.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/github/GithubOAuthProvider.java
@@ -51,9 +51,9 @@ public class GithubOAuthProvider extends com.epam.reportportal.auth.oauth.OAuthP
 
     public GithubOAuthProvider(GitHubUserReplicator githubReplicator,
                                AuthConfigService authConfigService,
-                               @Value("${rp.auth.github.tokenUrl:https://github.com/login/oauth/access_token}") String tokenUrl,
-                               @Value("${rp.auth.github.authUrl:https://github.com/login/oauth/authorize}") String authUrl,
-                               @Value("${rp.auth.github.apiUrl:https://api.github.com}") String githubBaseUrl) {
+                               @Value("${rp.auth.github.tokenUrl}") String tokenUrl,
+                               @Value("${rp.auth.github.authUrl}") String authUrl,
+                               @Value("${rp.auth.github.apiUrl}") String githubBaseUrl) {
         super("github", BUTTON, true);
         this.githubReplicator = githubReplicator;
         this.authConfigService = authConfigService;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,6 +76,11 @@ rp:
    auth:
         encryptor:
           password: reportportal
+        github:
+            apiUrl: https://api.github.com
+            authUrl: https://github.com/login/oauth/authorize
+            tokenUrl: https://github.com/login/oauth/access_token
+
 
 logging:
   level:


### PR DESCRIPTION
Trying to make it easy to use github enterprise by adding env variables. The default behavior stays the same.
Example
environment:
- RP_AUTH_GITHUB_APIURL=https://{{host}}/api/v3
- RP_AUTH_GITHUB_TOKENURL=https://{{host}}/login/oauth/access_token
- RP_AUTH_GITHUB_AUTHURL=https://{{host}}/login/oauth/authorize

issue #48