### PR TITLE
EPMRPP-84511 || Fix populate user details for SAML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
         compile 'com.epam.reportportal:commons-rules'
         compile 'com.epam.reportportal:commons-model'
     } else {
-        compile 'com.github.reportportal:commons-dao:02712fd2'
+        compile 'com.github.reportportal:commons-dao:d696687'
         compile 'com.github.reportportal:commons-rules:331c402'
         compile 'com.github.reportportal:commons-model:d61b714'
     }

--- a/src/main/java/com/epam/reportportal/auth/integration/saml/SamlUserReplicator.java
+++ b/src/main/java/com/epam/reportportal/auth/integration/saml/SamlUserReplicator.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.epam.reportportal.auth.util.AuthUtils.CROP_DOMAIN;
+import static com.epam.reportportal.auth.util.AuthUtils.NORMALIZE_STRING;
 
 /**
  * Replicates user from SAML response into database if it is not exist
@@ -112,7 +113,7 @@ public class SamlUserReplicator extends AbstractUserReplicator {
 	}
 
 	private void populateUserDetails(User user, List<Attribute> details) {
-		String email = findAttributeValue(details, UserAttribute.EMAIL.toString(), String.class);
+		String email = NORMALIZE_STRING.apply(findAttributeValue(details, UserAttribute.EMAIL.toString(), String.class));
 		checkEmail(email);
 		user.setEmail(email);
 
@@ -122,7 +123,7 @@ public class SamlUserReplicator extends AbstractUserReplicator {
 	}
 
 	private void populateUserDetailsIfSettingsArePresent(User user, Integration integration, List<Attribute> details) {
-		String email = findAttributeValue(details, SamlParameter.EMAIL_ATTRIBUTE.getParameter(integration).orElse(null), String.class);
+		String email = NORMALIZE_STRING.apply(findAttributeValue(details, SamlParameter.EMAIL_ATTRIBUTE.getParameter(integration).orElse(null), String.class));
 		checkEmail(email);
 		user.setEmail(email);
 

--- a/src/main/java/com/epam/reportportal/auth/util/AuthUtils.java
+++ b/src/main/java/com/epam/reportportal/auth/util/AuthUtils.java
@@ -42,4 +42,5 @@ public final class AuthUtils {
 
 	public static final Function<String, String> CROP_DOMAIN = it -> normalizeId(StringUtils.substringBefore(it, "@"));
 
+	public static final Function<String, String> NORMALIZE_STRING = original -> normalizeId(original.trim());
 }


### PR DESCRIPTION
Fix issue when SAML User Replication Rule checks and saves user email in case-sensitive. This fix allows us to avoid cases when two users have similar emails.