### PR TITLE
Update forward headers strategy to FRAMEWORK

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ datastore.thumbnail.avatar.height=\${rp.binarystore.thumbnail.avatar.height:60}
 # Application.yaml configuration
 # Server configuration
 server.port=9999
-server.forward-headers-strategy=NATIVE
+server.forward-headers-strategy=FRAMEWORK
 server.servlet.context-path=/
 
 # Spring configuration


### PR DESCRIPTION
This pull request updates the server configuration in the `application.properties` file to align with framework-level header forwarding strategies.

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L18-R18): Changed `server.forward-headers-strategy` from `NATIVE` to `FRAMEWORK` to ensure compatibility with the framework's handling of forwarded headers.