### PR TITLE
Add JWT issuer property

### DIFF
--- a/src/main/java/com/epam/reportportal/auth/TokenServicesFacade.java
+++ b/src/main/java/com/epam/reportportal/auth/TokenServicesFacade.java
@@ -118,6 +118,7 @@ public class TokenServicesFacade {
     JwtClaimsSet.Builder claimsBuilder = JwtClaimsSet.builder()
         .id(UUID.randomUUID().toString())
         .subject(username)
+        .audience(List.of("reportportal"))
         .claim("user_name", username)
         .claim("authorities", authorities.stream()
             .map(GrantedAuthority::getAuthority)

--- a/src/main/java/com/epam/reportportal/auth/TokenServicesFacade.java
+++ b/src/main/java/com/epam/reportportal/auth/TokenServicesFacade.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
@@ -40,37 +42,56 @@ import org.springframework.stereotype.Component;
 public class TokenServicesFacade {
 
   private final JwtEncoder jwtEncoder;
+  private final String issuer;
 
-  public TokenServicesFacade(JwtEncoder jwtEncoder) {
+  public TokenServicesFacade(JwtEncoder jwtEncoder, @Value("${rp.jwt.issuer}") String issuer) {
     this.jwtEncoder = jwtEncoder;
+    this.issuer = issuer;
   }
 
-  public Jwt createToken(ReportPortalClient client, String username,
+  public Jwt createToken(
+      ReportPortalClient client,
+      String username,
       Authentication userAuthentication,
-      Map<String, Serializable> extensionParams) {
+      Map<String, Serializable> extensionParams
+  ) {
     return createNonApiToken(client, username, userAuthentication, extensionParams);
   }
 
-  public Jwt createNonApiToken(ReportPortalClient client, String username,
+  public Jwt createNonApiToken(
+      ReportPortalClient client,
+      String username,
       Authentication userAuthentication,
-      Map<String, Serializable> extensionParams) {
+      Map<String, Serializable> extensionParams
+  ) {
     return createToken(client.name(), username, userAuthentication, extensionParams);
   }
 
-  private Jwt createToken(String clientId, String username, Authentication authentication,
-      Map<String, Serializable> extensionParams) {
+  private Jwt createToken(
+      String clientId,
+      String username,
+      Authentication authentication,
+      Map<String, Serializable> extensionParams
+  ) {
     Instant now = Instant.now();
 
     Instant expiry = now.plus(1, ChronoUnit.DAYS);
 
     JwtClaimsSet.Builder claimsBuilder = JwtClaimsSet.builder()
         .id(UUID.randomUUID().toString())
+        .subject(username)
+        .audience(List.of("reportportal"))
         .claim("user_name", username)
-        .claim("authorities", authentication.getAuthorities())
-        .issuedAt(Instant.now())
+        .claim("authorities", authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.toList()))
+        .issuedAt(now)
+        .notBefore(now)
         .expiresAt(expiry)
+        .issuer(issuer)
         .claim(OAuth2ParameterNames.CLIENT_ID, clientId)
-        .claim("scopes", List.of("ui"));
+        .claim("scopes", List.of("ui"))
+        .claim("token_type", "access_token");
 
     if (extensionParams != null) {
       extensionParams.forEach(claimsBuilder::claim);
@@ -84,20 +105,30 @@ public class TokenServicesFacade {
     return jwtEncoder.encode(parameters);
   }
 
-  public Jwt createToken(String clientId, String username, Collection<? extends GrantedAuthority> authorities,
-      Map<String, Serializable> extensionParams) {
+  public Jwt createToken(
+      String clientId,
+      String username,
+      Collection<? extends GrantedAuthority> authorities,
+      Map<String, Serializable> extensionParams
+  ) {
     Instant now = Instant.now();
 
     Instant expiry = now.plus(1, ChronoUnit.DAYS);
 
     JwtClaimsSet.Builder claimsBuilder = JwtClaimsSet.builder()
         .id(UUID.randomUUID().toString())
+        .subject(username)
         .claim("user_name", username)
-        .claim("authorities", authorities)
-        .issuedAt(Instant.now())
+        .claim("authorities", authorities.stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.toList()))
+        .issuedAt(now)
+        .notBefore(now)
         .expiresAt(expiry)
+        .issuer(issuer)
         .claim(OAuth2ParameterNames.CLIENT_ID, clientId)
-        .claim("scopes", List.of("ui"));
+        .claim("scopes", List.of("ui"))
+        .claim("token_type", "access_token");
 
     if (extensionParams != null) {
       extensionParams.forEach(claimsBuilder::claim);

--- a/src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java
+++ b/src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java
@@ -104,6 +104,9 @@ public class AuthorizationServerConfig {
   @Value("${rp.jwt.token.validity-period}")
   private Integer tokenValidity;
 
+  @Value("${rp.jwt.issuer}")
+  private String jwtIssuer;
+
   private final  ServerSettingsRepository serverSettingsRepository;
 
   private final  UserDetailsService userDetailsService;
@@ -222,7 +225,7 @@ public class AuthorizationServerConfig {
 
   @Bean
   public AuthenticationProvider ldapAuthProvider() {
-    return new LdapAuthProvider(authConfigRepository, eventPublisher, ldapDetailsContextMapper(), new TokenServicesFacade(jwtEncoder()));
+    return new LdapAuthProvider(authConfigRepository, eventPublisher, ldapDetailsContextMapper(), new TokenServicesFacade(jwtEncoder(), jwtIssuer));
   }
 
   @Bean("ldapDetailsContextMapper")
@@ -241,7 +244,7 @@ public class AuthorizationServerConfig {
   @Bean
   public AuthenticationProvider activeDirectoryAuthProvider() {
     return new ActiveDirectoryAuthProvider(authConfigRepository, eventPublisher,
-        activeDirectoryDetailsContextMapper(), new TokenServicesFacade(jwtEncoder()));
+        activeDirectoryDetailsContextMapper(), new TokenServicesFacade(jwtEncoder(), jwtIssuer));
   }
 
   @Bean("activeDirectoryDetailsContextMapper")

--- a/src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java
+++ b/src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java
@@ -41,7 +41,6 @@ import com.epam.reportportal.auth.store.MutableClientRegistrationRepository;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -262,9 +261,10 @@ public class AuthorizationServerConfig {
     if (StringUtils.hasText(signingKey)) {
       return signingKey;
     }
-    Optional<ServerSettings> secretKey = serverSettingsRepository.findByKey(SECRET_KEY);
-    return secretKey.isPresent() ? secretKey.get().getValue()
-        : serverSettingsRepository.generateSecret();
+
+    return serverSettingsRepository.findByKey(SECRET_KEY)
+        .map(ServerSettings::getValue)
+        .orElseGet(serverSettingsRepository::generateSecret);
   }
 
   @Bean

--- a/src/main/java/com/epam/reportportal/auth/dao/ServerSettingsRepository.java
+++ b/src/main/java/com/epam/reportportal/auth/dao/ServerSettingsRepository.java
@@ -18,7 +18,6 @@ package com.epam.reportportal.auth.dao;
 
 import com.epam.reportportal.auth.entity.ServerSettings;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 /**
@@ -26,7 +25,6 @@ import org.springframework.data.jpa.repository.Query;
  */
 public interface ServerSettingsRepository extends ReportPortalRepository<ServerSettings, Long> {
 
-  @Modifying
   @Query(value = "INSERT INTO server_settings (key, value) VALUES ('secret.key', gen_random_bytes(32)) RETURNING value", nativeQuery = true)
   String generateSecret();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,6 +59,7 @@ rp.db.pass=
 
 rp.jwt.signing-key=
 rp.jwt.token.validity-period=\${rp.session.live}
+rp.jwt.issuer=http://reportportal.internal
 
 rp.session.live=86400
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -58,6 +58,7 @@ rp.db.pass=
 
 rp.jwt.signing-key=
 rp.jwt.token.validity-period=\${rp.session.live}
+rp.jwt.issuer=http://reportportal.internal
 
 rp.session.live=86400
 


### PR DESCRIPTION
This pull request enhances JWT token generation by introducing issuer configuration and refining claim handling. The main changes improve token structure, ensure issuer consistency, and clean up related configuration and repository code.

**JWT Token Generation Improvements**
* Added support for configurable JWT issuer by injecting the `issuer` value from application properties into the `TokenServicesFacade` and using it in token claims. (`src/main/java/com/epam/reportportal/auth/TokenServicesFacade.java`, `src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java`) [[1]](diffhunk://#diff-d5f2429665452ff27961e2a3806723fdc65ef4d4eccf59a2e8ecdf1e47958b31R45-R94) [[2]](diffhunk://#diff-f66fe75dd01ae510b50e25b061ae570132e8741cb2f29ab7a04c63c23b2b6b96R106-R108) [[3]](diffhunk://#diff-f66fe75dd01ae510b50e25b061ae570132e8741cb2f29ab7a04c63c23b2b6b96L225-R227) [[4]](diffhunk://#diff-f66fe75dd01ae510b50e25b061ae570132e8741cb2f29ab7a04c63c23b2b6b96L244-R246) [[5]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R62) [[6]](diffhunk://#diff-0218b149293465d6bb4256c4c70e7d331ca030aaa1e56b1bcaf84f6f9a09b40eR61)
* Updated JWT claims to include `subject`, `audience`, `notBefore`, `token_type`, and formatted `authorities` as a list of strings for better standards compliance. (`src/main/java/com/epam/reportportal/auth/TokenServicesFacade.java`) [[1]](diffhunk://#diff-d5f2429665452ff27961e2a3806723fdc65ef4d4eccf59a2e8ecdf1e47958b31R45-R94) [[2]](diffhunk://#diff-d5f2429665452ff27961e2a3806723fdc65ef4d4eccf59a2e8ecdf1e47958b31L87-R132)

**Configuration and Dependency Injection**
* Modified `AuthorizationServerConfig` to inject the JWT issuer property and pass it to authentication providers, ensuring consistent token issuer across the application. (`src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java`) [[1]](diffhunk://#diff-f66fe75dd01ae510b50e25b061ae570132e8741cb2f29ab7a04c63c23b2b6b96R106-R108) [[2]](diffhunk://#diff-f66fe75dd01ae510b50e25b061ae570132e8741cb2f29ab7a04c63c23b2b6b96L225-R227) [[3]](diffhunk://#diff-f66fe75dd01ae510b50e25b061ae570132e8741cb2f29ab7a04c63c23b2b6b96L244-R246)

**Repository and Code Cleanup**
* Simplified `ServerSettingsRepository.generateSecret()` by removing the unnecessary `@Modifying` annotation and streamlining the secret retrieval logic in `AuthorizationServerConfig`. (`src/main/java/com/epam/reportportal/auth/dao/ServerSettingsRepository.java`, `src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java`) [[1]](diffhunk://#diff-c6120c1d99bfbe657aa72b24576e7f9a1d77e0bd17f7cfd7782680ea50cfdd4dL21-L29) [[2]](diffhunk://#diff-f66fe75dd01ae510b50e25b061ae570132e8741cb2f29ab7a04c63c23b2b6b96L262-R267)

**Property File Updates**
* Added the `rp.jwt.issuer` property to both main and test application properties for environment consistency. (`src/main/resources/application.properties`, `src/test/resources/application.properties`) [[1]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R62) [[2]](diffhunk://#diff-0218b149293465d6bb4256c4c70e7d331ca030aaa1e56b1bcaf84f6f9a09b40eR61)